### PR TITLE
Changes to allow PCSX2 to build

### DIFF
--- a/desktop-software.sh
+++ b/desktop-software.sh
@@ -443,7 +443,6 @@ get_software_type()
                 # add emulation softare to temp list
                 # remember to kick off script at the end of dep installs
                 software_list="$scriptdir/cfgs/software-lists/pcsx2-src-deps.txt"
-                m_install_pcsx2_src
         elif [[ "$type" == "upnp-dlna" ]]; then
                 # add emulation softare to temp list
                 # remember to kick off script at the end of dep installs
@@ -883,6 +882,10 @@ main()
 		# kick off helper script
 		install_mobile_upnp_dlna
 		
+	elif [[ "$type" == "pcsx2-testing" ]]; then
+	
+		# Ensure that Build-Depends are installed prior
+		m_install_pcsx2_src
 	fi
 	
 	# cleanup package leftovers

--- a/scriptmodules/emulators-from-src.shinc
+++ b/scriptmodules/emulators-from-src.shinc
@@ -31,7 +31,7 @@ show_warning()
 source_compiler_flags()
 {
 	
-if [[ $ARCH == i686 ]]; then
+if [[ $ARCH == "i386" ]]; then
     cmake .. \
       -DCMAKE_BUILD_TYPE='Release' \
       -DCMAKE_INSTALL_PREFIX='/usr' \
@@ -147,7 +147,7 @@ fi
   ############################
 
   # git dir evail check
-  PKG_check=$(ls "$git_dir" 2> /dev/null)
+  PKG_check=$(ls "$git_dir/build" 2> /dev/null)
   
   ############################
   # Begin $PKG build eval
@@ -177,15 +177,14 @@ fi
   		sleep 2s
   		
   		# build $PKG
-	  	if [[ -d build_dir ]]; then
-			rm -rf build_dir
-			mkdir build_dir
-		else
-			mkdir build_dir
-			cd build_dir 
+	  	if [[ -d build ]]; then
+			rm -rf build
 		fi
 		
+		mkdir build
+		
 		# set compiler flags and run cmake
+		#cd build
 	  	#source_compiler_flags
 	  	
 	  	# try simple build
@@ -209,15 +208,12 @@ fi
   	sleep 2s
   	
   	# build $PKG
-  	if [[ -d build_dir ]]; then
-		rm -rf build_dir
-		mkdir build_dir
-	else
-		mkdir build_dir
-		cd build_dir 
+  	if [[ -d build ]]; then
+		rm -rf build
 	fi
 
 	# set compiler flags and run cmake
+	#cd build
   	#source_compiler_flags
   	
   	# try simple build

--- a/scriptmodules/emulators-from-src.shinc
+++ b/scriptmodules/emulators-from-src.shinc
@@ -211,7 +211,9 @@ fi
   	if [[ -d build ]]; then
 		rm -rf build
 	fi
-
+	
+	mkdir build
+	
 	# set compiler flags and run cmake
 	#cd build
   	#source_compiler_flags


### PR DESCRIPTION
Here are some small changes that were needed to build PCSX2. There is more work to be done but I have been able to build the application using the build.sh script and via the source_compiler_flags function.