### PR TITLE
Small change to allow non-core Retroarch deb files to install.

### DIFF
--- a/scriptmodules/extra-pkgs.shinc
+++ b/scriptmodules/extra-pkgs.shinc
@@ -765,6 +765,12 @@ ep_install_eval_pkg()
 	# package eval routine using dpkg or gdebi
 	#####################################################
 	
+	# Reset any currently set value
+	PKG_OK=""
+	if [[ "$multi" == "n" ]]; then
+		# prcess only packages that are specifed by themselves
+		PKG_OK=$(dpkg-query -W --showformat='${Status}\n' $PKG | grep "install ok installed" 2> /dev/null)
+	fi
 	
 	# check and process for multiple debs
 	if [[ "$multi" == "y" ]]; then
@@ -791,10 +797,6 @@ ep_install_eval_pkg()
 
 		# remove temp install directory
 		rm -rf "/tmp/deb-install-tmp"
-
-
-	# prcess only packages that are specifed by themselves	
-	PKG_OK=$(dpkg-query -W --showformat='${Status}\n' $PKG | grep "install ok installed" 2> /dev/null)
 	
 	elif [[ "$multi" == "n" && "" == "$PKG_OK" ]]; then
 		


### PR DESCRIPTION
extra-pkgs.shinc would always say that retroarch, retroarch-assets, and retroarch-joypad-autoconfig were installed. The problem seemed to be due to $PKG_OK already being defined due to previous package checks. The following change resets $PKG_OK and checks the status of a package if $multi equals "n". This change works around the issue that I experienced and the non-core RetroArch packages now install properly.

Thanks for getting RetroArch working on SteamOS. I have been curious about RetroArch but I never used it before. It has been working pretty well so far.