### PR TITLE
Use httpredir.debian.org consistently

### DIFF
--- a/add-debian-repos.sh
+++ b/add-debian-repos.sh
@@ -293,13 +293,13 @@ main()
 		# Debian jessie
 		cat <<-EOF > ${sourcelist_tmp}
 		# Debian-jessie repo
-		deb ftp://mirror.nl.leaseweb.net/debian/ jessie main contrib non-free
-		deb-src ftp://mirror.nl.leaseweb.net/debian/ jessie main contrib non-free
+		deb http://httpredir.debian.org/debian/ jessie main contrib non-free
+		deb-src http://httpredir.debian.org/debian/ jessie main contrib non-free
 		EOF
 		
 		# Debian jessie-backports
 		cat <<-EOF > ${backports_sourcelist_tmp}
-		deb http://http.debian.net/debian jessie-backports main
+		deb http://httpredir.debian.org/debian jessie-backports main
 		EOF
 		
 		# packages.libregeek.org


### PR DESCRIPTION
Instead of using FTP (!) on a leaseweb mirror in the netherlands, let’s switch to Debian’s official HTTP redirector, which provides a better experience to users all around the world.